### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/tests/test_bucketlist.py
+++ b/tests/test_bucketlist.py
@@ -209,7 +209,7 @@ class BucketlistTestCase(unittest.TestCase):
                 headers = self.__class__.header
             )
             bucket = Bucketlist.query.get(index)
-            assert bucket == None
+            assert bucket is None
             assert req.status_code == 401
 
     def test_6_logout(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:andela-amwaleh:Bucketlist_flask?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:andela-amwaleh:Bucketlist_flask?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)